### PR TITLE
Updated ForgeDirection to EnumFacing

### DIFF
--- a/src/main/java/cofh/api/CoFHAPIProps.java
+++ b/src/main/java/cofh/api/CoFHAPIProps.java
@@ -6,6 +6,6 @@ public class CoFHAPIProps {
 
 	}
 
-	public static final String VERSION = "1.7.10R1.0.2";
+	public static final String VERSION = "1.8.9R1.0.0";
 
 }

--- a/src/main/java/cofh/api/energy/IEnergyConnection.java
+++ b/src/main/java/cofh/api/energy/IEnergyConnection.java
@@ -1,6 +1,6 @@
 package cofh.api.energy;
 
-import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraft.util.EnumFacing;
 
 /**
  * Implement this interface on TileEntities which should connect to energy transportation blocks. This is intended for blocks which generate energy but do not
@@ -16,6 +16,6 @@ public interface IEnergyConnection {
 	/**
 	 * Returns TRUE if the TileEntity can connect on a given side.
 	 */
-	boolean canConnectEnergy(ForgeDirection from);
+	boolean canConnectEnergy(EnumFacing from);
 
 }

--- a/src/main/java/cofh/api/energy/IEnergyHandler.java
+++ b/src/main/java/cofh/api/energy/IEnergyHandler.java
@@ -1,6 +1,6 @@
 package cofh.api.energy;
 
-import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraft.util.EnumFacing;
 
 /**
  * Implement this interface on Tile Entities which should handle energy, generally storing it in one or more internal {@link IEnergyStorage} objects.
@@ -26,7 +26,7 @@ public interface IEnergyHandler extends IEnergyProvider, IEnergyReceiver {
 	 * @return Amount of energy that was (or would have been, if simulated) received.
 	 */
 	@Override
-	int receiveEnergy(ForgeDirection from, int maxReceive, boolean simulate);
+	int receiveEnergy(EnumFacing from, int maxReceive, boolean simulate);
 
 	/**
 	 * Remove energy from an IEnergyProvider, internal distribution is left entirely to the IEnergyProvider.
@@ -40,19 +40,19 @@ public interface IEnergyHandler extends IEnergyProvider, IEnergyReceiver {
 	 * @return Amount of energy that was (or would have been, if simulated) extracted.
 	 */
 	@Override
-	int extractEnergy(ForgeDirection from, int maxExtract, boolean simulate);
+	int extractEnergy(EnumFacing from, int maxExtract, boolean simulate);
 
 
 	/**
 	 * Returns the amount of energy currently stored.
 	 */
 	@Override
-	int getEnergyStored(ForgeDirection from);
+	int getEnergyStored(EnumFacing from);
 
 	/**
 	 * Returns the maximum amount of energy that can be stored.
 	 */
 	@Override
-	int getMaxEnergyStored(ForgeDirection from);
+	int getMaxEnergyStored(EnumFacing from);
 
 }

--- a/src/main/java/cofh/api/energy/IEnergyProvider.java
+++ b/src/main/java/cofh/api/energy/IEnergyProvider.java
@@ -1,6 +1,6 @@
 package cofh.api.energy;
 
-import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraft.util.EnumFacing;
 
 /**
  * Implement this interface on Tile Entities which should provide energy, generally storing it in one or more internal {@link IEnergyStorage} objects.
@@ -23,16 +23,16 @@ public interface IEnergyProvider extends IEnergyConnection {
 	 *            If TRUE, the extraction will only be simulated.
 	 * @return Amount of energy that was (or would have been, if simulated) extracted.
 	 */
-	int extractEnergy(ForgeDirection from, int maxExtract, boolean simulate);
+	int extractEnergy(EnumFacing from, int maxExtract, boolean simulate);
 
 	/**
 	 * Returns the amount of energy currently stored.
 	 */
-	int getEnergyStored(ForgeDirection from);
+	int getEnergyStored(EnumFacing from);
 
 	/**
 	 * Returns the maximum amount of energy that can be stored.
 	 */
-	int getMaxEnergyStored(ForgeDirection from);
+	int getMaxEnergyStored(EnumFacing from);
 
 }

--- a/src/main/java/cofh/api/energy/IEnergyReceiver.java
+++ b/src/main/java/cofh/api/energy/IEnergyReceiver.java
@@ -1,6 +1,6 @@
 package cofh.api.energy;
 
-import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraft.util.EnumFacing;
 
 /**
  * Implement this interface on Tile Entities which should receive energy, generally storing it in one or more internal {@link IEnergyStorage} objects.
@@ -23,16 +23,16 @@ public interface IEnergyReceiver extends IEnergyConnection {
 	 *            If TRUE, the charge will only be simulated.
 	 * @return Amount of energy that was (or would have been, if simulated) received.
 	 */
-	int receiveEnergy(ForgeDirection from, int maxReceive, boolean simulate);
+	int receiveEnergy(EnumFacing from, int maxReceive, boolean simulate);
 
 	/**
 	 * Returns the amount of energy currently stored.
 	 */
-	int getEnergyStored(ForgeDirection from);
+	int getEnergyStored(EnumFacing from);
 
 	/**
 	 * Returns the maximum amount of energy that can be stored.
 	 */
-	int getMaxEnergyStored(ForgeDirection from);
+	int getMaxEnergyStored(EnumFacing from);
 
 }

--- a/src/main/java/cofh/api/energy/TileEnergyHandler.java
+++ b/src/main/java/cofh/api/energy/TileEnergyHandler.java
@@ -2,7 +2,7 @@ package cofh.api.energy;
 
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraft.util.EnumFacing;
 
 /**
  * Reference implementation of {@link IEnergyHandler}. Use/extend this or implement your own.
@@ -30,34 +30,34 @@ public class TileEnergyHandler extends TileEntity implements IEnergyHandler {
 
 	/* IEnergyConnection */
 	@Override
-	public boolean canConnectEnergy(ForgeDirection from) {
+	public boolean canConnectEnergy(EnumDirection from) {
 
 		return true;
 	}
 
 	/* IEnergyReceiver */
 	@Override
-	public int receiveEnergy(ForgeDirection from, int maxReceive, boolean simulate) {
+	public int receiveEnergy(EnumDirection from, int maxReceive, boolean simulate) {
 
 		return storage.receiveEnergy(maxReceive, simulate);
 	}
 
 	/* IEnergyProvider */
 	@Override
-	public int extractEnergy(ForgeDirection from, int maxExtract, boolean simulate) {
+	public int extractEnergy(EnumDirection from, int maxExtract, boolean simulate) {
 
 		return storage.extractEnergy(maxExtract, simulate);
 	}
 
 	/* IEnergyReceiver and IEnergyProvider */
 	@Override
-	public int getEnergyStored(ForgeDirection from) {
+	public int getEnergyStored(EnumDirection from) {
 
 		return storage.getEnergyStored();
 	}
 
 	@Override
-	public int getMaxEnergyStored(ForgeDirection from) {
+	public int getMaxEnergyStored(EnumDirection from) {
 
 		return storage.getMaxEnergyStored();
 	}


### PR DESCRIPTION
Since there are a lot more mods now on 1.8.9 we need an official RF api, since there are many unofficial ones.  I updated the ForgeDirection calls to EnumFacing to be compatible with 1.8 / 1.8.8 / 1.8.9